### PR TITLE
Use the forums native preview feature to generate the quick reply preview

### DIFF
--- a/extension/js/quick-reply.js
+++ b/extension/js/quick-reply.js
@@ -371,12 +371,27 @@ QuickReplyBox.prototype.fetchFormCookie = function(threadid) {
 };
 
 QuickReplyBox.prototype.updatePreview = function() {
-    if(jQuery('#post-message').val().length > 0) {
-        var parser = new PreviewParser(jQuery('#post-message').val(), this.sortedEmotes);
-        jQuery('#preview-content').html(parser.fetchResult());
+    let preview = document.querySelector('#preview-content');
+    let message = document.querySelector('#post-message');
 
-        var content = document.getElementById('topbar-preview');
-        content.scrollTop = content.scrollHeight;
+    if (message.value.length > 0) {
+        let body = new FormData(document.querySelector('#quick-reply-form'));
+
+        body.append('preview', 'Preview Reply');
+
+        fetch(this.reply_url, {body, credentials: 'include', method: 'POST'})
+            .then(response => response.text())
+            .catch(error => console.log(error))
+            .then(html => {
+                let parser = new DOMParser();
+                let doc = parser.parseFromString(html, 'text/html');
+
+                preview.innerHTML = doc.querySelector('div.inner.postbody').innerHTML;
+            });
+    }
+
+    else {
+        preview.innerHTML = '';
     }
 };
 


### PR DESCRIPTION
I changed the preview to work by submitting the preview form and parsing the response, it now uses native APIs instead of jQuery.

There is a race condition due to previous requests not being cancelled as you type, sometimes an older request will finish after a newer request and leave the preview stuck behind a few characters.

I'll need to figure out the best way to deal with it, simply cancelling the HTTP request isn't enough, because there's also asynchronous behaviour happening after the request is complete.