### PR TITLE
Build: Add support for Firefox extension building using web-ext

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,6 +4,11 @@
   "manifest_version": 2,
   "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC/ODZliWIb6YDyaHICQGfRDOiDmNOqCVPDNro6/Kwi1KpSFL7jI0Sn+HpvPt60Yb5tKPPMUIseTCSdDAjpr/d3aHU93r4g9ziq+wLKtTjuOryW/6izrGSf548A3QeyqIsWM+ONdbvOdU5bnXeAgIqa1CymocuJOASbvnz+ztaZXQIDAQAB",
   "description": "Enhances the Something Awful forums with a host of new and exciting features",
+  "applications": {
+    "gecko": {
+      "id": "SomethingAwfulLastReadRedux@Firefox"
+    }
+  },
   "icons": {
         "16": "images/logo16.png",
         "32": "images/logo32.png",
@@ -58,8 +63,10 @@
   ],
   "permissions":
     [
+        "*://forums.somethingawful.com/*",
         "tabs",
         "storage",
+        "unlimitedStorage",
         "management"
     ],
   "optional_permissions":

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "devDependencies": {
-    "archiver": "*",
-    "chrome-webstore-upload-cli": "^1.0.0"
+    "archiver": "^3.1.1",
+    "chrome-webstore-upload-cli": "^1.0.0",
+    "web-ext": "^4.0.0"
   },
   "scripts": {
     "release-chrome": "webstore upload --source=extension-chrome.zip --auto-publish",


### PR DESCRIPTION
I've worked Firefox extension building into the existing build.js.

For build.js:
I set it up based on the way the travis config is set up - travis calls the script with `firefox` or `chrome` as a parameter. Currently, if no browser is specified when calling build.js, nothing will happen. Is that fine for default behavior, or do we want something different?

For the manifest:
I added the Firefox-specific keys I've been using. There's now a host permission for the forums in order to smooth out various cross-origin nonsense. Considering the possibility of zealous user/thread note users  eventually running up against the `storage.local` quota, `unlimitedStorage` might as well be added at the same time to avoid having to bother users again in the future.