### PR TITLE
Rename application to browser_specific_settings

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,7 +4,7 @@
   "manifest_version": 2,
   "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC/ODZliWIb6YDyaHICQGfRDOiDmNOqCVPDNro6/Kwi1KpSFL7jI0Sn+HpvPt60Yb5tKPPMUIseTCSdDAjpr/d3aHU93r4g9ziq+wLKtTjuOryW/6izrGSf548A3QeyqIsWM+ONdbvOdU5bnXeAgIqa1CymocuJOASbvnz+ztaZXQIDAQAB",
   "description": "Enhances the Something Awful forums with a host of new and exciting features",
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "SomethingAwfulLastReadRedux@Firefox"
     }


### PR DESCRIPTION
At some point in the last few years, Firefox renamed the manifest.json field from `applications` to `browser_specific_settings` (see https://wiki.developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json$revision/1445286 for revision where this happens in the docs). I'm not sure if this is absolutely necessary to get `web-ext` to work, or if it would be possible to remove this field, or just inject it at build-time for submission to Firefox extensions site.