### PR TITLE
flip show user avatar to be hide user avatar

### DIFF
--- a/extension/js/message-handler.js
+++ b/extension/js/message-handler.js
@@ -145,8 +145,8 @@ defaultSettings['expandBreadcrumbs']            = 'false';
 defaultSettings['displayMods']                  = 'false';
 
 // Thread Options
-defaultSettings['showUserAvatarImage']          = 'true';
-defaultSettings['showUserAvatar']               = 'true';
+defaultSettings['hideUserAvatarImage']          = 'false';
+defaultSettings['hideUserAvatar']               = 'false';
 defaultSettings['hideUserGrenade']              = 'false';
 defaultSettings['hideGarbageDick']              = 'false';
 //defaultSettings['hideStupidNewbie']             = 'false';
@@ -310,39 +310,13 @@ function getPageSettings() {
  *
  */
 function fixSettings() {
-    if (localStorage.getItem('disableCustomButtons') == 'true') {
-        localStorage.setItem('displayCustomButtons', 'false');
-        localStorage.removeItem('disableCustomButtons');
-    } else if (localStorage.getItem('disableCustomButtons') == 'false') {
-        localStorage.setItem('displayCustomButtons', 'true');
-        localStorage.removeItem('disableCustomButtons');
+    if (localStorage.getItem('showUserAvatar') !== null) {
+        localStorage.setItem('hideUserAvatar', (localStorage.getItem('showUserAvatar') == 'false').toString());
+        localStorage.removeItem('showUserAvatar');
     }
-    if (localStorage.getItem('ignore_bookmark_star')) {
-        localStorage.setItem('ignoreBookmarkStar', localStorage.getItem('ignore_bookmark_star'));
-        localStorage.removeItem('ignore_bookmark_star');
-    }
-    if (localStorage.getItem('highlightCancer')) {
-        localStorage.setItem('fixCancer', localStorage.getItem('highlightCancer'));
-        localStorage.removeItem('highlightCancer');
-    }
-    if (localStorage.getItem('saveUserNotes') != 'true') {
-        localStorage.setItem('userNotesLocal',localStorage.getItem('userNotesOld'));
-        localStorage.setItem('saveUserNotes','true');
-    }
-
-    if (localStorage.getItem('embedVideo')) {
-        if (localStorage.getItem('enableQuickReply') != 'true') {
-            chrome.permissions.remove({ origins: ['https://api.imgur.com/*'] });
-        }
-        if (localStorage.getItem('inlineTweet') != 'true') {
-            chrome.permissions.remove({ origins: ['https://api.twitter.com/*'] });
-        }
-        localStorage.removeItem('embedVideo');
-    }
-
-    if (localStorage.getItem('enableSOAPLink')) {
-        localStorage.setItem('enableSAARSLink', localStorage.getItem('enableSOAPLink'));
-        localStorage.removeItem('enableSOAPLink');
+    if (localStorage.getItem('showUserAvatarImage') !== null) {
+        localStorage.setItem('hideUserAvatarImage', (localStorage.getItem('showUserAvatarImage') == 'false').toString());
+        localStorage.removeItem('showUserAvatarImage');
     }
 }
 

--- a/extension/js/salr.js
+++ b/extension/js/salr.js
@@ -156,15 +156,18 @@ SALR.prototype.pageInit = function() {
                 this.threadNotes();
             }
 
+            console.log(this.settings.hideUserAvatar);
+            console.log(this.settings.hideUserAvatarImage);
+            //zephmod - hide/show avatar entirely
+            if (this.settings.hideUserAvatar == 'true') {
+                jQuery("#thread dl.userinfo dd.title").remove();
+            }
             //zephmod - hide/show avatar image
-            if (this.settings.showUserAvatarImage != 'true') {
+            else if (this.settings.hideUserAvatarImage == 'true') {
                 jQuery("#thread dl.userinfo dd.title img").remove();
             }
 
-            //zephmod - hide/show avatar entirely
-            if (this.settings.showUserAvatar != 'true') {
-                jQuery("#thread dl.userinfo dd.title").remove();
-            }
+
 
             if (this.settings.hideGarbageDick == 'true') {
                 jQuery("img[src*='fi.somethingawful.com/images/newbie.gif']").css({'display':'none'});
@@ -328,7 +331,7 @@ SALR.prototype.openSettings = function() {
     postMessage({'message': 'OpenSettings'});
 };
 
-/** 
+/**
  * Hides top/bottom navigation menu links based on user settings.
  * A false user setting implies something should be hidden.
  */
@@ -589,7 +592,7 @@ SALR.prototype.updateStyling = function() {
     }
 };
 
-/** 
+/**
  * This function will eventually be the only one iterating through the posts table.
  */
 SALR.prototype.handleShowThread = function() {
@@ -621,7 +624,7 @@ SALR.prototype.handleShowThread = function() {
     for (let post of posts) {
         if (post.id === 'post') // adbot
             continue;
-        let profileLink = post.querySelector('ul.profilelinks a[href*="userid="]'); 
+        let profileLink = post.querySelector('ul.profilelinks a[href*="userid="]');
         if (!profileLink)
             continue;
 
@@ -645,7 +648,7 @@ SALR.prototype.handleShowThread = function() {
 };
 
 /**
- * 
+ *
  * @param {Object} modList  Object containing list of mods.
  * @param {string} userid   string userid of mod to update.
  * @param {string} username username of mod to update.
@@ -1148,7 +1151,7 @@ SALR.prototype.highlightPost = function(post, userid, friends_id, modList) {
         return;
 
     if (this.settings.hideUserGrenade === 'true') {
-        if (userNameBox.className.trim() === 'author platinum' || 
+        if (userNameBox.className.trim() === 'author platinum' ||
             userNameBox.className.trim() === 'author platinum op')
                 userNameBox.classList.remove("platinum");
     }
@@ -1818,7 +1821,7 @@ SALR.prototype.clickToggleAvatar = function(idToToggle, hiddenAvatars, event) {
     var reachedSelf = false;
 
     for (let post of posts) {
-        let profileLink = post.querySelector('ul.profilelinks a[href*="userid="]'); 
+        let profileLink = post.querySelector('ul.profilelinks a[href*="userid="]');
         if (!profileLink)
             continue;
         let posterId = profileLink.href.match(/userid=(\d+)/i)[1];

--- a/extension/js/salr.js
+++ b/extension/js/salr.js
@@ -156,8 +156,6 @@ SALR.prototype.pageInit = function() {
                 this.threadNotes();
             }
 
-            console.log(this.settings.hideUserAvatar);
-            console.log(this.settings.hideUserAvatarImage);
             //zephmod - hide/show avatar entirely
             if (this.settings.hideUserAvatar == 'true') {
                 jQuery("#thread dl.userinfo dd.title").remove();

--- a/extension/js/settings-handler.js
+++ b/extension/js/settings-handler.js
@@ -112,8 +112,8 @@ document.addEventListener('DOMContentLoaded', () => {
     defaultSettings['displayMods']                  = 'false';
 
     // Thread Options
-    defaultSettings['showUserAvatarImage']          = 'true';
-    defaultSettings['showUserAvatar']               = 'true';
+    defaultSettings['hideUserAvatarImage']          = 'false';
+    defaultSettings['hideUserAvatar']               = 'false';
     defaultSettings['hideUserGrenade']              = 'false';
     defaultSettings['hideGarbageDick']              = 'false';
     //defaultSettings['hideStupidNewbie']             = 'false';

--- a/extension/settings.html
+++ b/extension/settings.html
@@ -572,10 +572,10 @@
     <section class="settings-panel">
         <!-- zephmod -->
         <div class='display-preference'>
-            <label><input id='showUserAvatar' class='user-preference' type='checkbox' /> Show User Avatar/Title</label>
+            <label><input id='hideUserAvatar' class='user-preference' type='checkbox' /> Hide User Avatar/Title</label>
         </div>
         <div class='display-preference'>
-            <label><input id='showUserAvatarImage' class='user-preference' type='checkbox' /> Show User Avatar's Image</label>
+            <label><input id='hideUserAvatarImage' class='user-preference' type='checkbox' /> Hide User Avatar's Image</label>
         </div>
         <!-- /zephmod -->
         <div class='display-preference'>


### PR DESCRIPTION
Closes #86 

Makes the settings be:
"Hide User Avatar/Title"
"Hide User Avatar Image"

where they are off by default and can be activated. As stated in the issue, this brings this setting inline with the other settings in that activating it will give your behavior different from the regular forums.

I also took this opportunity to get rid of the setting changes that were bunches of years old. At this point, I feel like it after 3, 7, or 10 years, users have probably either upgraded salr-redux, or moved onto a less dead comedy forum. 