### PR TITLE
Fix hiding nav list URLs using a contains attribute selector

### DIFF
--- a/extension/js/salr.js
+++ b/extension/js/salr.js
@@ -409,7 +409,12 @@ SALR.prototype.applyNavMenuStyling = function() {
             else {
                 settingToNavLinkMap.forEach((value, key) => {
                     if (settings[key] === 'false') {
-                        navList.querySelector('a[href*="' + value + '"]').parentNode.style.display = 'none';
+                        const elem = navList.querySelector('a[href*="' + value + '"]');
+                        if (!elem) {
+                            console.error(`Could not find element for ${key}`);
+                            continue;
+                        }
+                        elem.parentNode.style.display = 'none';
                     }
                 });
                 if (settings.topLogout === 'false') {

--- a/extension/js/salr.js
+++ b/extension/js/salr.js
@@ -409,7 +409,7 @@ SALR.prototype.applyNavMenuStyling = function() {
             else {
                 settingToNavLinkMap.forEach((value, key) => {
                     if (settings[key] === 'false') {
-                        navList.querySelector('a[href="' + value + '"]').parentNode.style.display = 'none';
+                        navList.querySelector('a[href*="' + value + '"]').parentNode.style.display = 'none';
                     }
                 });
                 if (settings.topLogout === 'false') {


### PR DESCRIPTION
The URL for the forums changed and is no longer a relative fragment.  This is causing the script to fail if the user tries to remove the link to the front page.  Switching the attribute selector to a contains search will match the partial URL.